### PR TITLE
Set SecurityFunction key to empty in Table

### DIFF
--- a/Source/nHydrate.Generator/Models/Table.cs
+++ b/Source/nHydrate.Generator/Models/Table.cs
@@ -125,6 +125,7 @@ namespace nHydrate.Generator.Models
             _compositeList = new TableCompositeCollection(root, this);
             _componentList = new TableComponentCollection(root, this);
             _security = new SecurityFunction(root, this);
+            _security.ResetKey(Guid.Empty.ToString());
 
             _staticData = new RowEntryCollection(this.Root);
             _columns = new ReferenceCollection(this.Root, this, ReferenceType.Column);


### PR DESCRIPTION
The key value for security functions in the lastgen file changes
every time the model is generated.  This causes headaches in a
multi-developer environment because it leads to unnecessary source
control conflicts.

The security function is always a nested element under the table
and the key is never used, so the key can just be set to the empty
GUID like many of the other nested elements.  This ensures that
the key value will never change in the file and eliminates the
extra conflicts.
