### PR TITLE
Fix 'EntityGeneratedTemplate's to obey the ModelRoot.TransformNames

### DIFF
--- a/Source/nHydrate.Generator.EFCodeFirst/Generators/Entity/EntityGeneratedTemplate.cs
+++ b/Source/nHydrate.Generator.EFCodeFirst/Generators/Entity/EntityGeneratedTemplate.cs
@@ -451,14 +451,14 @@ namespace nHydrate.Generator.EFCodeFirst.Generators.Entity
 
             if (_item.AllowCreateAudit)
             {
-                sb.AppendLine("			newItem." + _model.Database.CreatedDateColumnName + " = item." + _model.Database.CreatedDateColumnName + ";");
-                sb.AppendLine("			newItem." + _model.Database.CreatedByColumnName + " = item." + _model.Database.CreatedByColumnName + ";");
+                sb.AppendLine("			newItem." + _model.Database.CreatedDatePascalName + " = item." + _model.Database.CreatedDatePascalName + ";");
+                sb.AppendLine("			newItem." + _model.Database.CreatedByPascalName + " = item." + _model.Database.CreatedByPascalName + ";");
             }
 
             if (_item.AllowModifiedAudit)
             {
-                sb.AppendLine("			newItem." + _model.Database.ModifiedDateColumnName + " = item." + _model.Database.ModifiedDateColumnName + ";");
-                sb.AppendLine("			newItem." + _model.Database.ModifiedByColumnName + " = item." + _model.Database.ModifiedByColumnName + ";");
+                sb.AppendLine("			newItem." + _model.Database.ModifiedDatePascalName + " = item." + _model.Database.ModifiedDatePascalName + ";");
+                sb.AppendLine("			newItem." + _model.Database.ModifiedByPascalName + " = item." + _model.Database.ModifiedByPascalName + ";");
             }
 
             sb.AppendLine("			return newItem;");

--- a/Source/nHydrate.Generator.EFDAL/Generators/Entity/EntityGeneratedTemplate.cs
+++ b/Source/nHydrate.Generator.EFDAL/Generators/Entity/EntityGeneratedTemplate.cs
@@ -395,14 +395,14 @@ namespace nHydrate.Generator.EFDAL.Generators.EFCSDL
 
             if (_item.AllowCreateAudit)
             {
-                sb.AppendLine("			newItem." + _model.Database.CreatedDateColumnName + " = item." + _model.Database.CreatedDateColumnName + ";");
-                sb.AppendLine("			newItem." + _model.Database.CreatedByColumnName + " = item." + _model.Database.CreatedByColumnName + ";");
+                sb.AppendLine("			newItem." + _model.Database.CreatedDatePascalName + " = item." + _model.Database.CreatedDatePascalName + ";");
+                sb.AppendLine("			newItem." + _model.Database.CreatedByPascalName + " = item." + _model.Database.CreatedByPascalName + ";");
             }
 
             if (_item.AllowModifiedAudit)
             {
-                sb.AppendLine("			newItem." + _model.Database.ModifiedDateColumnName + " = item." + _model.Database.ModifiedDateColumnName + ";");
-                sb.AppendLine("			newItem." + _model.Database.ModifiedByColumnName + " = item." + _model.Database.ModifiedByColumnName + ";");
+                sb.AppendLine("			newItem." + _model.Database.ModifiedDatePascalName + " = item." + _model.Database.ModifiedDatePascalName + ";");
+                sb.AppendLine("			newItem." + _model.Database.ModifiedByPascalName + " = item." + _model.Database.ModifiedByPascalName + ";");
             }
 
             sb.AppendLine("			return newItem;");


### PR DESCRIPTION
When generating our model, we noticed that even though the model root setting "Transform Names" was set to true, the generated entities did not properly generate the Clone method.  Instead of transforming the names of the Created By, Created Date, Modified By and Modified Date properties as pascal case, it would use the raw db column name.  This resulted it generated entities that would not compile.  This fixes the generators to properly transform the names.
