### PR TITLE
Modify CompareAudits() to accept a null as parameter one or two

### DIFF
--- a/Source/nHydrate.Generator.EFCodeFirst/Generators/AuditEntity/AuditEntityGeneratedTemplate.cs
+++ b/Source/nHydrate.Generator.EFCodeFirst/Generators/AuditEntity/AuditEntityGeneratedTemplate.cs
@@ -433,8 +433,19 @@ namespace Widgetsphere.Generator.EFCodeFirst.Generators.AuditEntity
             sb.AppendLine("			var retval = new " + this.GetLocalNamespace() + ".AuditResult<" + _item.PascalName + "Audit>(item1, item2);");
             sb.AppendLine("			var differences = new List<I" + _item.PascalName + "AuditResultFieldCompare>();");
             sb.AppendLine();
+			sb.AppendLine("			if(item1 == null || item2 == null){");
+			sb.AppendLine("			    item1 = item1 ?? item2;");
+			sb.AppendLine("			    item2 = item2 ?? item1;");			
 
             foreach (Column column in _item.GetColumns().Where(x => x.Generated).OrderBy(x => x.Name))
+            {
+                if (!(column.DataType == System.Data.SqlDbType.Text || column.DataType == System.Data.SqlDbType.NText || column.DataType == System.Data.SqlDbType.Image))
+                {
+                    sb.AppendLine("				differences.Add(new " + _item.PascalName + "AuditResultFieldCompare<" + column.GetCodeType(true) + ">(item1." + column.PascalName + ", item2." + column.PascalName + ", " + this.GetLocalNamespace() + ".Entity." + _item.PascalName + ".FieldNameConstants." + column.PascalName + ", typeof(" + column.GetCodeType(false) + ")));");
+                }
+            }
+			sb.AppendLine("			}else{");
+			foreach (Column column in _item.GetColumns().Where(x => x.Generated).OrderBy(x => x.Name))
             {
                 if (!(column.DataType == System.Data.SqlDbType.Text || column.DataType == System.Data.SqlDbType.NText || column.DataType == System.Data.SqlDbType.Image))
                 {
@@ -442,7 +453,7 @@ namespace Widgetsphere.Generator.EFCodeFirst.Generators.AuditEntity
                     sb.AppendLine("				differences.Add(new " + _item.PascalName + "AuditResultFieldCompare<" + column.GetCodeType(true) + ">(item1." + column.PascalName + ", item2." + column.PascalName + ", " + this.GetLocalNamespace() + ".Entity." + _item.PascalName + ".FieldNameConstants." + column.PascalName + ", typeof(" + column.GetCodeType(false) + ")));");
                 }
             }
-
+			sb.AppendLine("			}");
             sb.AppendLine();
             sb.AppendLine("			retval.Differences = (IEnumerable<" + this.GetLocalNamespace() + ".IAuditResultFieldCompare>)differences;");
             sb.AppendLine("			return retval;");


### PR DESCRIPTION
modified AuditEntity > AppendCompare to generate a function CompareAudits() to accept a null for parameter 1 or 2.  Still not both.

If one or the other is null then it assumes all columns have changed and adds them all to the difference list.