### PR TITLE
Update supported Visual Studio versions to 16.x

### DIFF
--- a/Source/nHydrate.DslPackage/source.extension.tt
+++ b/Source/nHydrate.DslPackage/source.extension.tt
@@ -28,7 +28,7 @@
     <Description><#= this.Dsl.Description #></Description>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[12.0,15.0]" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/Source/nHydrate.DslPackage/source.extension.vsixmanifest
+++ b/Source/nHydrate.DslPackage/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>This is the nHydrate Visual Modeler</Description>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[12.0,15.0]" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Fix for #51

This should allow the plugin to at least install in the latest 2019 Visual Studio.  There may be some other compatibility issues that we can address later.

@gravbox @midnight-sun 

This should tell Visual Studio 2019 that it is compatible, though I was unable to get my VS 2019 Experimental Hive working this late.  @gravbox Do you mind double checking this?